### PR TITLE
Update `get_steric_parameters()`

### DIFF
--- a/src/smores/_internal/molecule.py
+++ b/src/smores/_internal/molecule.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import rdkit.Chem.AllChem as rdkit
 
+from smores._internal.combine import Combination
 from smores._internal.constants import streusel_radii
 from smores._internal.steric_parameters import StericParameters
 
@@ -93,16 +94,71 @@ class Molecule:
         )
 
     def get_dummy_index(self) -> int:
+        """
+        Get the index of the dummy atom.
+
+        Returns:
+            The index of the dummy atom.
+
+        """
         return self._morfeus_dummy_index - 1
 
     def get_attached_index(self) -> int:
+        """
+        Get the index of the atom attached to the substituent.
+
+        Returns:
+            The index of the atom attached to the substituent.
+
+        """
         return self._morfeus_attached_index - 1
 
     def get_excluded_indices(self) -> typing.Iterable[int]:
+        """
+        Yield indices of atoms excluded from the parameter calculation.
+
+        Yields:
+            The index of an excluded atom.
+
+        """
         if self._morfeus_excluded_indices is None:
             return
         for index in self._morfeus_excluded_indices:
             yield index - 1
+
+    @classmethod
+    def from_combination(
+        cls,
+        combination: Combination,
+        radii: npt.ArrayLike | None = None,
+    ) -> "Molecule":
+        """
+        Get a molecule from a :class:`.Combination`.
+
+        The molecule will automatically use the dummy and attached
+        index defined in `combination` and set all the
+        :attr:`~.Combination.core_indices` as excluded indices.
+
+        Parameters:
+
+            combination:
+                A combination of a core and substituent molecule.
+
+            radii (list[float]):
+                The radius of each atom of the molecule. If
+                ``None`` the STREUSEL_ radii will be used.
+
+        Returns:
+            The molecule.
+
+        """
+        return cls.from_rdkit(
+            molecule=combination.product,
+            dummy_index=combination.dummy_index,
+            attached_index=combination.attached_index,
+            excluded_indices=combination.core_indices,
+            radii=radii,
+        )
 
     @classmethod
     def from_xyz_file(
@@ -165,6 +221,9 @@ class Molecule:
     def from_mol_file(
         cls,
         path: pathlib.Path | str,
+        dummy_index: int,
+        attached_index: int,
+        excluded_indices: typing.Iterable[int] | None = None,
         radii: npt.ArrayLike | None = None,
     ) -> "Molecule":
         """
@@ -174,6 +233,16 @@ class Molecule:
 
             path:
                 The path to the file.
+
+            dummy_index:
+                The index of the dummy atom.
+
+            attached_index:
+                The index of the attached atom of the substituent.
+
+            excluded_indices (list[int]):
+                The indices of atoms which are not included in the
+                parameter calculation.
 
             radii (list[float]):
                 The radius of each atom of the molecule. If
@@ -195,12 +264,22 @@ class Molecule:
             )
         else:
             instance._radii = np.array(radii)
+        instance._morfeus_dummy_index = dummy_index + 1
+        instance._morfeus_attached_index = attached_index + 1
+        instance._morfeus_excluded_indices = (
+            None
+            if excluded_indices is None
+            else tuple(index + 1 for index in excluded_indices)
+        )
         return instance
 
     @classmethod
     def from_smiles(
         cls,
         smiles: str,
+        dummy_index: int,
+        attached_index: int,
+        excluded_indices: typing.Iterable[int] | None = None,
         positions: npt.ArrayLike | None = None,
         radii: npt.ArrayLike | None = None,
     ) -> "Molecule":
@@ -211,6 +290,16 @@ class Molecule:
 
             smiles:
                 The SMILES of the molecule.
+
+            dummy_index:
+                The index of the dummy atom.
+
+            attached_index:
+                The index of the attached atom of the substituent.
+
+            excluded_indices (list[int]):
+                The indices of atoms which are not included in the
+                parameter calculation.
 
             positions (list[list[float]]):
                 The coordinates of each atom of the molecule
@@ -250,6 +339,13 @@ rdkit.Chem.rdDistGeom.html#rdkit.Chem.rdDistGeom.ETKDGv3
             )
         else:
             instance._radii = np.array(radii)
+        instance._morfeus_dummy_index = dummy_index + 1
+        instance._morfeus_attached_index = attached_index + 1
+        instance._morfeus_excluded_indices = (
+            None
+            if excluded_indices is None
+            else tuple(index + 1 for index in excluded_indices)
+        )
 
         return instance
 
@@ -257,6 +353,9 @@ rdkit.Chem.rdDistGeom.html#rdkit.Chem.rdDistGeom.ETKDGv3
     def from_rdkit(
         cls,
         molecule: rdkit.Mol,
+        dummy_index: int,
+        attached_index: int,
+        excluded_indices: typing.Iterable[int] | None = None,
         radii: npt.ArrayLike | None = None,
         conformer_id: int = 0,
     ) -> "Molecule":
@@ -268,6 +367,16 @@ rdkit.Chem.rdDistGeom.html#rdkit.Chem.rdDistGeom.ETKDGv3
             molecule:
                 The :mod:`rdkit` molecule. It must have at least
                 one conformer.
+
+            dummy_index:
+                The index of the dummy atom.
+
+            attached_index:
+                The index of the attached atom of the substituent.
+
+            excluded_indices (list[int]):
+                The indices of atoms which are not included in the
+                parameter calculation.
 
             radii (list[float]):
                 The radius of each atom of the molecule. If
@@ -296,6 +405,14 @@ rdkit.Chem.rdDistGeom.html#rdkit.Chem.rdDistGeom.ETKDGv3
             )
         else:
             instance._radii = np.array(radii)
+
+        instance._morfeus_dummy_index = dummy_index + 1
+        instance._morfeus_attached_index = attached_index + 1
+        instance._morfeus_excluded_indices = (
+            None
+            if excluded_indices is None
+            else tuple(index + 1 for index in excluded_indices)
+        )
 
         return instance
 

--- a/tests/molecule/test_get_steric_parameters.py
+++ b/tests/molecule/test_get_steric_parameters.py
@@ -24,19 +24,14 @@ def test_smores_parameters_match_sterimol_if_same_radii_are_used(
     case_data: CaseData,
 ) -> None:
 
-    dummy_index = 0
-    attached_index = 1
     sterimol = morfeus.Sterimol(
         elements=case_data.atoms,
         coordinates=case_data.positions,
-        dummy_index=dummy_index + 1,
-        attached_index=attached_index + 1,
+        dummy_index=case_data.molecule.get_dummy_index() + 1,
+        attached_index=case_data.molecule.get_attached_index() + 1,
         radii=case_data.radii,
     )
-    params = case_data.molecule.get_steric_parameters(
-        dummy_index=dummy_index,
-        attached_index=attached_index,
-    )
+    params = case_data.molecule.get_steric_parameters()
     assert params.L == pytest.approx(sterimol.L_value, abs=1e-4)
     assert params.B1 == pytest.approx(sterimol.B_1_value)
     assert params.B5 == pytest.approx(sterimol.B_5_value)
@@ -65,6 +60,8 @@ def default_init_molecule(rdkit_molecule: rdkit.Mol) -> CaseData:
             atoms=tuple(
                 atom.GetSymbol() for atom in rdkit_molecule.GetAtoms()
             ),
+            dummy_index=0,
+            attached_index=1,
             positions=rdkit_molecule.GetConformer(0).GetPositions(),
             radii=radii,
         ),
@@ -84,7 +81,12 @@ def molecule_from_xyz_file(
         atoms=tuple(atom.GetSymbol() for atom in rdkit_molecule.GetAtoms()),
         positions=rdkit_molecule.GetConformer(0).GetPositions(),
         radii=radii,
-        molecule=smores.Molecule.from_xyz_file(xyz_file, radii),
+        molecule=smores.Molecule.from_xyz_file(
+            path=xyz_file,
+            dummy_index=0,
+            attached_index=1,
+            radii=radii,
+        ),
     )
 
 
@@ -101,7 +103,12 @@ def molecule_from_mol_file(
         atoms=tuple(atom.GetSymbol() for atom in rdkit_molecule.GetAtoms()),
         positions=rdkit_molecule.GetConformer(0).GetPositions(),
         radii=radii,
-        molecule=smores.Molecule.from_mol_file(mol_file, radii),
+        molecule=smores.Molecule.from_mol_file(
+            path=mol_file,
+            dummy_index=0,
+            attached_index=1,
+            radii=radii,
+        ),
     )
 
 
@@ -114,6 +121,8 @@ def molecule_from_smiles(rdkit_molecule: rdkit.Mol) -> CaseData:
         radii=radii,
         molecule=smores.Molecule.from_smiles(
             smiles=rdkit.MolToSmiles(rdkit_molecule),
+            dummy_index=0,
+            attached_index=1,
             positions=rdkit_molecule.GetConformer(0).GetPositions(),
             radii=radii,
         ),

--- a/validation/catalytic_reactions/one_substituent/4_calculate_steric_parameters.py
+++ b/validation/catalytic_reactions/one_substituent/4_calculate_steric_parameters.py
@@ -41,11 +41,12 @@ def main() -> None:
 
             for row in tuple(_get_rows(catalyst_input_file)):
 
-                smores_molecule = smores.Molecule.from_xyz_file(row.xyz_file)
-                smores_params = smores_molecule.get_steric_parameters(
+                smores_molecule = smores.Molecule.from_xyz_file(
+                    path=row.xyz_file,
                     dummy_index=row.dummy_index,
                     attached_index=row.attached_index,
                 )
+                smores_params = smores_molecule.get_steric_parameters()
                 writer.writerow(
                     {
                         "name": row.name,
@@ -66,12 +67,14 @@ def main() -> None:
                 with open(row.fragments_file) as f:
                     core_indices = json.load(f)["core_indices"]
 
+                smores_core_excluded_molecule = smores.Molecule.from_xyz_file(
+                    path=row.xyz_file,
+                    dummy_index=row.dummy_index,
+                    attached_index=row.attached_index,
+                    excluded_indices=core_indices,
+                )
                 smores_core_excluded_params = (
-                    smores_molecule.get_steric_parameters(
-                        dummy_index=row.dummy_index,
-                        attached_index=row.attached_index,
-                        excluded_indices=core_indices,
-                    )
+                    smores_core_excluded_molecule.get_steric_parameters()
                 )
                 writer.writerow(
                     {

--- a/validation/catalytic_reactions/one_substituent/4_calculate_steric_parameters.py
+++ b/validation/catalytic_reactions/one_substituent/4_calculate_steric_parameters.py
@@ -94,12 +94,11 @@ def main() -> None:
                 )
 
                 smores_esp_molecule = smores.EspMolecule.from_cube_file(
-                    row.xyz_file.parent / "ESP.cube"
-                )
-                esp_smores_params = smores_esp_molecule.get_steric_parameters(
+                    path=row.xyz_file.parent / "ESP.cube",
                     dummy_index=row.dummy_index,
                     attached_index=row.attached_index,
                 )
+                esp_smores_params = smores_esp_molecule.get_steric_parameters()
                 writer.writerow(
                     {
                         "name": row.name,

--- a/validation/common_carbon_substituents/3_calculate_steric_parameters.py
+++ b/validation/common_carbon_substituents/3_calculate_steric_parameters.py
@@ -37,11 +37,12 @@ def main() -> None:
 
         for row in tuple(_get_rows(args.input_file)):
 
-            smores_molecule = smores.Molecule.from_xyz_file(row.xyz_file)
-            smores_params = smores_molecule.get_steric_parameters(
+            smores_molecule = smores.Molecule.from_xyz_file(
+                path=row.xyz_file,
                 dummy_index=row.dummy_index,
                 attached_index=row.attached_index,
             )
+            smores_params = smores_molecule.get_steric_parameters()
             writer.writerow(
                 {
                     "name": row.name,


### PR DESCRIPTION
Removed the arguments `dummy_index`, `attached_index` and
`excluded_indices` from `Molecule` and `EspMolecule` and
add them into the various initializers. Also added
`get_dummy_index()`, `get_attached_index()` and
`get_excluded_indices()` so that users can easily retrieve
these values.

The reason the arguments are removed from `get_steric_parameters()`
is that I do not think that users will be calling this function
with many different values of these parameters. Rather, I expect a
user has a fixed dummy and attached index for each molecule. By
providing them in the initializer, the user does not have to worry
about storing these values in a secondary structure. In addition,
if later down the line the user wishes to know which dummy index
and attached index was used to calculate the steric parameters,
it will be easy to figure out by using `get_dummy_index()` etc.